### PR TITLE
Allowing deepmerge of dictionaries

### DIFF
--- a/pconf/pconf.py
+++ b/pconf/pconf.py
@@ -3,7 +3,7 @@ from .store import env
 from .store import file
 from .store import memory
 
-from six import iteritems
+from deepmerge import Merger
 
 
 class Pconf(object):
@@ -16,6 +16,12 @@ class Pconf(object):
     After sources are set the values can be accessed by calling get()
     """
     __hierarchy = []
+
+    merger = Merger(
+        [(dict, ["merge"])],
+        ["override"],
+        ["override"]
+    )
 
     @classmethod
     def get(cls):
@@ -30,10 +36,11 @@ class Pconf(object):
         """
         results = {}
 
-        for storeMethod in cls.__hierarchy:
-            for key, value in iteritems(storeMethod.get()):
-                if key not in results:
-                    results[key] = value
+        hierarchy = cls.__hierarchy
+        hierarchy.reverse()
+
+        for storeMethod in hierarchy:
+            cls.merger.merge(results, storeMethod.get())
 
         return results
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pyyaml>=3.13
 six
+deepmerge==0.0.4

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7'
     ],
-    install_requires=['pyyaml', 'six'],
+    install_requires=['pyyaml', 'six', 'deepmerge'],
     extras_require={
         'test': ['pytest', 'mock'],
     },

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="pconf",
-    version="1.5.0",
+    version="1.5.1",
     author="Andras Maroy",
     author_email="andras@maroy.hu",
     description=("Hierarchical python configuration with files, environment variables, command-line arguments."),

--- a/tests/integration/test_integration_argv.py
+++ b/tests/integration/test_integration_argv.py
@@ -4,6 +4,9 @@ from pconf import Pconf
 
 
 class TestIntegrationArgv(IntegrationBase):
+    
+    maxDiff = None
+
     def test_integration(self):
         sys.argv.append("pconf")
         sys.argv.append("--bool")

--- a/tests/test_hierarchy.py
+++ b/tests/test_hierarchy.py
@@ -3,67 +3,65 @@ from mock import patch, MagicMock
 from pconf import Pconf
 
 
-TEST_FILE_PATH = 'test'
-TEST_FILE_RESULT = {'file': 'result', 'overlapping': 'file'}
-TEST_ENV_RESULT = {'env': 'result', 'overlapping': 'env'}
-
-
 class TestHierarchy(TestCase):
+
+
     def setUp(self):
         Pconf._Pconf__hierarchy = []
+        self.TEST_FILE_PATH = 'test'
+        self.TEST_FILE_RESULT = {'file': 'result', 'overlapping': 'file', 'deep': {'stillhere': 'stillhere', 'overlapping': 'file'}}
+        self.TEST_ENV_RESULT = {'env': 'result', 'overlapping': 'env', 'deep': {'overlapping': 'env'}}
 
     @patch('pconf.store.env.Env')
     @patch('pconf.store.file.File')
     def test_forward(self, mock_file, mock_env):
         mocked_env = MagicMock()
-        mocked_env.get.return_value = TEST_ENV_RESULT
-        mock_env.return_value = mocked_env
+        mocked_env.get.return_value = self.TEST_ENV_RESULT
+        mock_env.return_value  = mocked_env
 
         mocked_file = MagicMock()
-        mocked_file.get.return_value = TEST_FILE_RESULT
-        mock_file.return_value = mocked_file
+        mocked_file.get.return_value = self.TEST_FILE_RESULT
+        mock_file.return_value  = mocked_file
 
         Pconf.env()
-        Pconf.file(TEST_FILE_PATH)
+        Pconf.file(self.TEST_FILE_PATH)
         results = Pconf.get()
 
-        self.assertEqual(results['overlapping'], TEST_ENV_RESULT['overlapping'])
-        for key in TEST_FILE_RESULT:
-            if key == 'overlapping':
-                continue
-            self.assertTrue(key in results)
-            self.assertEqual(results[key], TEST_FILE_RESULT[key])
+        expected = {
+            'file': 'result',
+            'env': 'result',
+            'overlapping': 'env',
+            'deep': {
+                'stillhere': 'stillhere',
+                'overlapping': 'env'
+            }
+        }
 
-        for key in TEST_ENV_RESULT:
-            if key == 'overlapping':
-                continue
-            self.assertTrue(key in results)
-            self.assertEqual(results[key], TEST_ENV_RESULT[key])
+        self.assertEqual(expected, results)
 
     @patch('pconf.store.env.Env')
     @patch('pconf.store.file.File')
     def test_backward(self, mock_file, mock_env):
         mocked_env = MagicMock()
-        mocked_env.get.return_value = TEST_ENV_RESULT
-        mock_env.return_value = mocked_env
+        mocked_env.get.return_value = self.TEST_ENV_RESULT
+        mock_env.return_value  = mocked_env
 
         mocked_file = MagicMock()
-        mocked_file.get.return_value = TEST_FILE_RESULT
+        mocked_file.get.return_value = self.TEST_FILE_RESULT
         mock_file.return_value = mocked_file
 
-        Pconf.file(TEST_FILE_PATH)
+        Pconf.file(self.TEST_FILE_PATH)
         Pconf.env()
         results = Pconf.get()
 
-        self.assertEqual(results['overlapping'], TEST_FILE_RESULT['overlapping'])
-        for key in TEST_FILE_RESULT:
-            if key == 'overlapping':
-                continue
-            self.assertTrue(key in results)
-            self.assertEqual(results[key], TEST_FILE_RESULT[key])
+        expected = {
+            'file': 'result',
+            'env': 'result',
+            'overlapping': 'file',
+            'deep': {
+                'stillhere': 'stillhere',
+                'overlapping': 'file'
+            }
+        }
 
-        for key in TEST_ENV_RESULT:
-            if key == 'overlapping':
-                continue
-            self.assertTrue(key in results)
-            self.assertEqual(results[key], TEST_ENV_RESULT[key])
+        self.assertEqual(expected, results)


### PR DESCRIPTION
## Proposed Changes
  - Allowing deepmerge of dictionaries.


When I have the following yaml structure:
```yaml
parent:
   child1: value1
   child2: value2
   child3: value3
```
Then I have a environment variable that overrides child3:
```shell 
parent__child3=value4 python myscript.py
```
This result in the following config:
```python
{'parent': {'value3': 'override3'}}
```
This PR fixes this.