### PR TITLE
parse environment variable values before splitting the key

### DIFF
--- a/pconf/store/env.py
+++ b/pconf/store/env.py
@@ -92,11 +92,11 @@ class Env(object):
             if self.__valid_key(key):
                 self.vars[key] = env_vars[key]
 
-        if self.separator is not None:
-            self.__split_vars(self.vars)
-
         if self.parse_values:
             self.__try_parse(self.vars)
+
+        if self.separator is not None:
+            self.__split_vars(self.vars)
 
     def __to_lower(self, key):
         return key.lower()


### PR DESCRIPTION
Attempting to parse the values after splitting them results
in an AttributeError being thrown as now you're attempting
to parse dictionaries rather than primitives.

Fixes #14

## Proposed Changes

  - Changes order of operations when both environment variable splitting and value parsing are enabled.
